### PR TITLE
Restricción de administradores autorizados

### DIFF
--- a/gnerd/Back/gcobros_api/controllers/admins/adminsController.js
+++ b/gnerd/Back/gcobros_api/controllers/admins/adminsController.js
@@ -19,7 +19,7 @@ const createAdmin = async (req, res) => {
 
 
         if (!userInDB) {
-            const user = await getUserByEmail('iconos@gnerd.mx');
+            const user = await getUserByEmail(email);
 
             if (!user) {
                 return res.status(400).json(handleErrorResponse({ message: 'El correo electrónico no es válido.' }));
@@ -47,6 +47,27 @@ const createAdmin = async (req, res) => {
     }
 }
 
+
+const validateIsValidAdmin = async (req, res) => {
+    try {
+        const { email } = req.body;
+
+        if (!email) {
+            return res.status(400).json(handleErrorResponse({ message: 'El correo electrónico es requerido.' }));
+        }
+        const userInDB = await Admin.findOne({ where: { primaryEmail: email, suspended: false } });
+        if (!userInDB) {
+            res.status(400).json(handleErrorResponse({ message: 'Administrador no válido.' }));
+        } else {
+            res.json(handleResponse(userInDB));
+        }
+    } catch (error) {
+        console.error(error);
+        res.status(500).json(handleErrorResponse({ message: "Error interno del servidor" }));
+    }
+}
+
 module.exports = {
     createAdmin,
+    validateIsValidAdmin
 };

--- a/gnerd/Back/gcobros_api/routes/adminRoutes.js
+++ b/gnerd/Back/gcobros_api/routes/adminRoutes.js
@@ -2,9 +2,11 @@ const express = require('express');
 const router = express.Router();
 
 const {
-    createAdmin
+    createAdmin,
+    validateIsValidAdmin
 } = require("../controllers/admins/adminsController.js");
 
 router.post("/create", createAdmin);
+router.post('/validate', validateIsValidAdmin)
 
 module.exports = router;

--- a/gnerd/Front/gcobros_web/src/pages/api/admin/admin_api.js
+++ b/gnerd/Front/gcobros_web/src/pages/api/admin/admin_api.js
@@ -1,0 +1,21 @@
+export async function validateAdmin(email) {
+    try {
+        const response = await fetch('http://127.0.0.1:3001/api/admin/validate', {
+            method: 'POST',
+            headers: {
+                'Content-Type': 'application/json',
+            },
+            body: JSON.stringify({ email })
+        });
+
+        const result = await response.json();
+
+        if (!response.ok) {
+            throw new Error(result.error.message || 'Error inesperado en el servidor.');
+        }
+
+        return result.success && result.data;
+    } catch (error) {
+        throw new Error(error.message);
+    }
+}

--- a/gnerd/Front/gcobros_web/src/pages/api/auth/[...nextauth].js
+++ b/gnerd/Front/gcobros_web/src/pages/api/auth/[...nextauth].js
@@ -2,6 +2,7 @@ import NextAuth from "next-auth/next";
 import Google from "next-auth/providers/google";
 import { getAllDomains } from "../subscriptions/subscription_api";
 import { getAllAdmins } from '../directory/directory_api';
+import { validateAdmin } from '../admin/admin_api';
 
 export const authOptions = {
   debug: process.env.NODE_ENV === 'development',
@@ -32,10 +33,8 @@ export const authOptions = {
       }
       try {
         // Comprobración del catalogo de administradores
-        console.log('Antes de obtener los administradores')
-        const allAdmins = await getAllAdmins();
-        console.log('Despues de obtener los administradores')
-        if (allAdmins.some(admin => admin.primaryEmail === profile.email)) {
+        const isValidAdmin = await validateAdmin(profile.email);
+        if (isValidAdmin) {
           return true;
         }
 


### PR DESCRIPTION
# Restricción
Al administrar los registros de administradores autorizados únicamente desde el catálogo del directory API, se realiza la revisión si esa cuenta del directory ya está registrada en el sistema como un administrador, en caso de que no, entonces simplemente da un accesso denegado.